### PR TITLE
Site updates: card padding fix, Solomon rename, 2026 award, env var rename

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -59,7 +59,7 @@ The application uses a hybrid approach for GitHub data:
 
 ### Environment Configuration
 
-- `GITHUB_ACCESS_TOKEN` - Server-side GitHub API token (optional)
+- `NEXT_PRIVATE_GITHUB_ACCESS_TOKEN` - Server-side GitHub API token (optional)
 - `NEXT_PUBLIC_POSTHOG_KEY` - PostHog analytics key (optional)
 - `GITHUB_USERNAME` - Hardcoded in `lib/env.ts` as "pixxle"
 

--- a/components/languages-certifications-awards.tsx
+++ b/components/languages-certifications-awards.tsx
@@ -26,6 +26,7 @@ function LanguageItem({ language, level, isNative }: LanguageItemProps) {
 }
 
 export default function LanguagesCertificationsAwards() {
+  const [isManagerModalOpen, setIsManagerModalOpen] = useState(false);
   const [isAwardModalOpen, setIsAwardModalOpen] = useState(false);
   const [isNominationModalOpen, setIsNominationModalOpen] = useState(false);
 
@@ -66,6 +67,14 @@ export default function LanguagesCertificationsAwards() {
         <div className="border-t border-gray-700 pt-3">
           <div className="mb-3">
             <button
+              onClick={() => setIsManagerModalOpen(true)}
+              className="cursor-pointer border-none bg-transparent p-0 text-left font-normal text-blue-400 hover:underline"
+            >
+              2026 Manager of the Year
+            </button>
+          </div>
+          <div className="mb-3">
+            <button
               onClick={() => setIsAwardModalOpen(true)}
               className="cursor-pointer border-none bg-transparent p-0 text-left font-normal text-blue-400 hover:underline"
             >
@@ -82,6 +91,27 @@ export default function LanguagesCertificationsAwards() {
           </div>
         </div>
       </div>
+
+      {/* Manager of the Year Modal */}
+      <Modal
+        isOpen={isManagerModalOpen}
+        onClose={() => setIsManagerModalOpen(false)}
+        title="2026 Manager of the Year - MedHelp Care"
+      >
+        <div className="text-gray-300">
+          <h3 className="mb-3 text-lg font-medium text-blue-300">Award Motivation</h3>
+          <p className="mb-4 border-l-4 border-blue-800 bg-gray-800/30 py-2 pl-4 italic">
+            &ldquo;With a clear drive to develop both people and ways of working, he has carried out
+            important changes in the development team that strengthen quality and security. He is a
+            steady and sharp leader who sees his colleagues and builds a team that both thrives and
+            performs at a high level. He combines structure and direction with curiosity and
+            engagement, even during periods of high tempo. As leader of the company&apos;s largest
+            team and a driving force in the Terveystalo project, he delivers strong results without
+            compromising on quality or team spirit, while also being an important culture bearer
+            who contributes to community and positive energy throughout the organization.&rdquo;
+          </p>
+        </div>
+      </Modal>
 
       {/* Award Modal */}
       <Modal

--- a/components/languages-certifications-awards.tsx
+++ b/components/languages-certifications-awards.tsx
@@ -107,8 +107,8 @@ export default function LanguagesCertificationsAwards() {
             performs at a high level. He combines structure and direction with curiosity and
             engagement, even during periods of high tempo. As leader of the company&apos;s largest
             team and a driving force in the Terveystalo project, he delivers strong results without
-            compromising on quality or team spirit, while also being an important culture bearer
-            who contributes to community and positive energy throughout the organization.&rdquo;
+            compromising on quality or team spirit, while also being an important culture bearer who
+            contributes to community and positive energy throughout the organization.&rdquo;
           </p>
         </div>
       </Modal>

--- a/components/project-card.tsx
+++ b/components/project-card.tsx
@@ -10,7 +10,7 @@ interface ProjectCardProps {
 export default function ProjectCard({ title, description, href }: ProjectCardProps) {
   const content = (
     <div
-      className={`h-full rounded-md border border-gray-700 bg-[#0d1117] p-4${href ? 'transition-colors hover:border-gray-500' : ''}`}
+      className={`h-full rounded-md border border-gray-700 bg-[#0d1117] p-6 ${href ? 'transition-colors hover:border-gray-600' : ''}`}
     >
       <div className="flex items-start justify-between">
         <h3 className="text-lg font-medium text-white">{title}</h3>

--- a/components/projects-section.tsx
+++ b/components/projects-section.tsx
@@ -11,9 +11,9 @@ export default function ProjectsSection() {
 
       <div className="grid grid-cols-1 gap-4 md:grid-cols-2">
         <ProjectCard
-          title="CodeHephaestus"
+          title="Solomon"
           description="State machine for refining and automatically building features using Claude Code."
-          href="https://github.com/Pixxle/CodeHephaestus"
+          href="https://github.com/Pixxle/Solomon"
         />
         <ProjectCard
           title="vinterfjard.com"

--- a/lib/env.ts
+++ b/lib/env.ts
@@ -1,5 +1,5 @@
-// Note: For server-side env variables like GITHUB_ACCESS_TOKEN,
-// access them directly in server components using process.env.GITHUB_ACCESS_TOKEN
+// Note: For server-side env variables like NEXT_PRIVATE_GITHUB_ACCESS_TOKEN,
+// access them directly in server components using process.env.NEXT_PRIVATE_GITHUB_ACCESS_TOKEN
 // This file only exports client-safe environment variables
 
 export const GITHUB_USERNAME = 'pixxle'; // Replace with your actual GitHub username or make it configurable

--- a/lib/github.ts
+++ b/lib/github.ts
@@ -1,7 +1,7 @@
 'use server';
 
 // Import directly from process.env as we are in a server component
-const GITHUB_ACCESS_TOKEN = process.env.GITHUB_ACCESS_TOKEN;
+const NEXT_PRIVATE_GITHUB_ACCESS_TOKEN = process.env.NEXT_PRIVATE_GITHUB_ACCESS_TOKEN;
 import { mockUserProfile, mockContributionCalendar, mockUserActivity } from './mock-github-data';
 
 const GITHUB_API_URL = 'https://api.github.com/graphql';
@@ -18,11 +18,11 @@ export async function executeGitHubGraphQL<T>(
 
   console.log(`[GitHub API ${requestId}] Starting ${operationName} request`, {
     variables,
-    hasToken: !!GITHUB_ACCESS_TOKEN,
+    hasToken: !!NEXT_PRIVATE_GITHUB_ACCESS_TOKEN,
     url: GITHUB_API_URL,
   });
 
-  if (!GITHUB_ACCESS_TOKEN) {
+  if (!NEXT_PRIVATE_GITHUB_ACCESS_TOKEN) {
     console.warn(
       `[GitHub API ${requestId}] GitHub access token is not configured. Using mock data or limited API access.`
     );
@@ -37,8 +37,8 @@ export async function executeGitHubGraphQL<T>(
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',
-        ...(GITHUB_ACCESS_TOKEN && {
-          Authorization: `Bearer ${GITHUB_ACCESS_TOKEN}`,
+        ...(NEXT_PRIVATE_GITHUB_ACCESS_TOKEN && {
+          Authorization: `Bearer ${NEXT_PRIVATE_GITHUB_ACCESS_TOKEN}`,
         }),
       },
       body: JSON.stringify({
@@ -75,7 +75,7 @@ export async function executeGitHubGraphQL<T>(
       // If we get a 401 Unauthorized or 403 Forbidden, likely due to missing or invalid token
       if (response.status === 401 || response.status === 403) {
         console.warn(
-          `[GitHub API ${requestId}] GitHub API authorization failed. Please check your GITHUB_ACCESS_TOKEN in .env.local`
+          `[GitHub API ${requestId}] GitHub API authorization failed. Please check your NEXT_PRIVATE_GITHUB_ACCESS_TOKEN in .env.local`
         );
         // Return a minimal mock object instead of throwing
         return {} as T;
@@ -121,7 +121,7 @@ export async function getUserProfile(username: string) {
   console.log(`[getUserProfile] Fetching profile for user: ${username}`);
 
   // If no GitHub token is available, return mock data
-  if (!GITHUB_ACCESS_TOKEN) {
+  if (!NEXT_PRIVATE_GITHUB_ACCESS_TOKEN) {
     console.log(`[getUserProfile] Using mock GitHub profile data (no token available)`);
     return mockUserProfile;
   }
@@ -177,7 +177,7 @@ export async function getUserContributions(username: string) {
   console.log(`[getUserContributions] Fetching contributions for user: ${username}`);
 
   // If no GitHub token is available, return mock data
-  if (!GITHUB_ACCESS_TOKEN) {
+  if (!NEXT_PRIVATE_GITHUB_ACCESS_TOKEN) {
     console.log(`[getUserContributions] Using mock GitHub contribution data (no token available)`);
     return mockContributionCalendar;
   }
@@ -246,7 +246,7 @@ export async function getUserActivity(username: string) {
   console.log(`[getUserActivity] Fetching activity for user: ${username}`);
 
   // If no GitHub token is available, return mock data
-  if (!GITHUB_ACCESS_TOKEN) {
+  if (!NEXT_PRIVATE_GITHUB_ACCESS_TOKEN) {
     console.log(`[getUserActivity] Using mock GitHub activity data (no token available)`);
     return mockUserActivity;
   }


### PR DESCRIPTION
## Summary
- **Project card padding fix** — `components/project-card.tsx` had a broken template literal (`p-4${href ? ...}`) that concatenated into `p-4transition-colors`, silently invalidating the padding class so borders sat on the text. Fixed the missing space, bumped to `p-6`, and switched the hover border to `gray-600` so the card matches the Gists card style.
- **Project rename** — `CodeHephaestus` → `Solomon` (display name + repo URL → https://github.com/Pixxle/Solomon).
- **New award** — added "2026 Manager of the Year" (MedHelp Care) to the Experience page Awards list, including a modal with the translated Swedish motivation text. Listed first so it stays in reverse-chronological order.
- **Env var rename** — `GITHUB_ACCESS_TOKEN` → `NEXT_PRIVATE_GITHUB_ACCESS_TOKEN` across `lib/github.ts`, `lib/env.ts`, and `CLAUDE.md`. Matches the updated `.env` and Next.js's `NEXT_PRIVATE_` server-only convention.

## Test plan
- [ ] `/projects` — cards have visible padding; hover state matches `/gists`; "Solomon" appears in place of "CodeHephaestus" and links to the renamed repo.
- [ ] `/experience` — "2026 Manager of the Year" sits at the top of Awards; clicking opens the modal with the translated motivation under "MedHelp Care".
- [ ] Homepage renders real GitHub data (followers, contributions, bio) — confirms the renamed env var is being read. Server logs should show `hasToken: true` on GitHub API calls.
- [ ] `npm run build` succeeds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)